### PR TITLE
Adeus barra de rolagem.

### DIFF
--- a/app/assets/stylesheets/_image-header.scss
+++ b/app/assets/stylesheets/_image-header.scss
@@ -1,7 +1,5 @@
 // image-header.scss
 .image-header {
-  @extend .row;
-
   margin-top: -20px;
   margin-bottom: 20px;
   color: $body-bg;

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -25,6 +25,6 @@ html lang="#{I18n.locale}"
     div[class="image-header #{current_page?(:root) ? '' : 'small'}"]
       = yield :header
 
-    .row
-      .container
+    .container
+      .row
         = yield


### PR DESCRIPTION
Ajuste na ordem das tags do layout e no css do _image-header com o objetivo de remover a barra de rolagem que era exibida por padrão no final das páginas.