### PR TITLE
Change general strategy for database cleaner

### DIFF
--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -1,1 +1,2 @@
+DatabaseCleaner.strategy = :transaction
 DatabaseCleaner.url_whitelist = ['postgres://postgres:postgres@db:5432']


### PR DESCRIPTION
Fixing broken build after database_cleaner update.

I need set the env var `DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true`, too.